### PR TITLE
ci: run the test suite on pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,60 @@
+name: CI
+
+# The test suite ran only on a release tag, so a pull request could be merged
+# on the strength of the version-sync check alone -- the one check that did run
+# compares two version strings and knows nothing about the code. #46, #47 and
+# #48 all merged that way, and the tests they added did not run in CI until
+# afterwards, on the tag.
+#
+# Deliberately the *same* job releases.yml gates on, called rather than copied.
+# A CI job that has drifted from the release gate is worse than no CI job at
+# all, because it reports green on something other than what ships.
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_call:
+
+# Superseding a pull request run is safe and saves a fair amount of time when a
+# branch is pushed repeatedly. Release runs are never cancelled: this is also
+# the release gate, and cancelling it would fail the packaging jobs behind it.
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  test:
+    name: Lint, Test, and Build Assets
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          lfs: true
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Install Node dependencies
+        run: npm ci
+      - name: Install Python dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r py/requirements.txt
+          python -m pip install pytest
+      - name: Lint JavaScript
+        run: npm run lint
+        continue-on-error: true
+      - name: Build frontend bundle
+        run: npm run build
+      - name: Check Python sources compile
+        run: python -m compileall py
+      - name: Run Python tests
+        run: python -m pytest py/tests -q
+        # node:test ships with Node 22, so the main-process logic is covered
+        # without adding a test framework. It is pure by construction -- no
+        # electron import, network injected -- precisely so it can run here.
+      - name: Run JavaScript tests
+        run: npm run test:js

--- a/.github/workflows/releases.yml
+++ b/.github/workflows/releases.yml
@@ -15,40 +15,11 @@ permissions:
   contents: write
 
 jobs:
+  # The same job that guards every pull request, called rather than repeated.
+  # Two copies would drift, and the copy that drifts is always the one deciding
+  # whether a release is fit to build.
   test:
-    name: Lint, Test, and Build Assets
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          lfs: true
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 22
-      - uses: actions/setup-python@v5
-        with:
-          python-version: '3.11'
-      - name: Install Node dependencies
-        run: npm ci
-      - name: Install Python dependencies
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install -r py/requirements.txt
-          python -m pip install pytest
-      - name: Lint JavaScript
-        run: npm run lint
-        continue-on-error: true
-      - name: Build frontend bundle
-        run: npm run build
-      - name: Check Python sources compile
-        run: python -m compileall py
-      - name: Run Python tests
-        run: python -m pytest py/tests -q
-        # node:test ships with Node 22, so the main-process logic is covered
-        # without adding a test framework. It is pure by construction -- no
-        # electron import, network injected -- precisely so it can run here.
-      - name: Run JavaScript tests
-        run: npm run test:js
+    uses: ./.github/workflows/ci.yml
 
   package-desktop:
     name: Package desktop apps


### PR DESCRIPTION
The test suite ran only on a release tag. The one check a pull request actually got — *Ensure Node and Python versions match* — compares two version strings and knows nothing about the code.

So **#46, #47 and #48 were each merged green without a single test having run**, and the tests those PRs were *adding* did not run in CI until afterwards, on the tag. A test that only runs after the merge cannot stop the merge.

**This PR is its own proof:** the check list below should now include *Lint, Test, and Build Assets*.

## Why not just add `pull_request` to `releases.yml`

Because `package-desktop` builds installers and publishes them with `--publish always`. Adding the trigger there would have made every pull request try to cut a release.

The test job moves into its own `ci.yml` instead — triggered on pull requests and on pushes to `main` — and `releases.yml` now **calls** that workflow:

```yaml
  test:
    uses: ./.github/workflows/ci.yml
```

Called rather than copied on purpose. Two definitions drift, and the one that drifts is always the one deciding whether a release is fit to build. A CI job reporting green on something other than what ships is worse than no CI job at all.

Packaging is untouched and still runs only on a `v*` tag or manual dispatch; `package-desktop` and `package-pi` still gate on `needs: test`, which now resolves to the called workflow.

## What is deliberately unchanged

**Lint stays non-blocking** (`continue-on-error: true`), exactly as it was. There are currently 0 errors and 12 pre-existing `no-console` / `no-alert` warnings. Making lint fail a build is a policy change and does not belong in the commit that gets the tests running — worth doing separately if you want it, and cheap now that the error count is zero.

## Cancellation

Pull request runs cancel their own superseded runs. Release runs never do — this is also the release gate, and cancelling it would fail the packaging jobs waiting behind it:

```yaml
cancel-in-progress: ${{ github.event_name == 'pull_request' }}
```

## Verified

Both workflows parse, and the job graph resolves: `ci.yml` exposes `workflow_call`, `releases.yml` keeps `push: tags: v*` and `workflow_dispatch` only, and both packaging jobs still depend on `test`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
