### PR TITLE
chore(deps): move electron from 38.8.6 to 43.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -25,7 +25,7 @@
         "bootstrap-icons": "^1.13.1",
         "concurrently": "^9.2.1",
         "css-loader": "^7.1.2",
-        "electron": "^38.2.0",
+        "electron": "^43.3.0",
         "electron-builder": "^26.0.12",
         "eslint": "^9.39.5",
         "eslint-config-airbnb-extended": "^3.2.0",
@@ -1580,6 +1580,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=14.17.0"
+      }
+    },
+    "node_modules/@electron-internal/extract-zip": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@electron-internal/extract-zip/-/extract-zip-1.0.5.tgz",
+      "integrity": "sha512-+bqFCP98pLI0Tt0XQo1TmlXtwjWchISndDOxCkEcIuUgXWpBnLyRI+2DU+mesvnMMX6L1XDqYNA0lXNDHd/yiA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=22.12.0"
       }
     },
     "node_modules/@electron/asar": {
@@ -3147,17 +3157,6 @@
       "integrity": "sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
-    "node_modules/@types/yauzl": {
-      "version": "2.10.3",
-      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
-      "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
       "dependencies": {
         "@types/node": "*"
       }
@@ -4741,16 +4740,6 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
-    "node_modules/buffer-crc32": {
-      "version": "0.2.13",
-      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
-      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
@@ -5755,22 +5744,22 @@
       }
     },
     "node_modules/electron": {
-      "version": "38.8.6",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-38.8.6.tgz",
-      "integrity": "sha512-lyBhcVi9QYAZL6FO6r5twAWAjWnYomo3iVDvrb5SJZlq928BGemHOKG0tPIq41NOLaCu9f3XdEEjMkjQPjprRg==",
+      "version": "43.3.0",
+      "resolved": "https://registry.npmjs.org/electron/-/electron-43.3.0.tgz",
+      "integrity": "sha512-nLlvu0WFjftWsSaTkV2B/c4NDuJBspTyXu8vKSQ6vLvFt8uG3NgN49LLKcXddwX0GqVvAQDhciWp+4xOdTdhew==",
       "dev": true,
-      "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@electron/get": "^2.0.0",
-        "@types/node": "^22.7.7",
-        "extract-zip": "^2.0.1"
+        "@electron-internal/extract-zip": "^1.0.1",
+        "@electron/get": "^5.0.0",
+        "@types/node": "^24.9.0"
       },
       "bin": {
-        "electron": "cli.js"
+        "electron": "cli.js",
+        "install-electron": "install.js"
       },
       "engines": {
-        "node": ">= 12.20.55"
+        "node": ">= 22.12.0"
       }
     },
     "node_modules/electron-builder": {
@@ -6013,6 +6002,23 @@
       "engines": {
         "node": ">=6 <7 || >=8"
       }
+    },
+    "node_modules/electron/node_modules/@types/node": {
+      "version": "24.13.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
+      "integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
+    },
+    "node_modules/electron/node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/emoji-regex": {
       "version": "9.2.2",
@@ -7125,27 +7131,6 @@
       "dev": true,
       "license": "Apache-2.0"
     },
-    "node_modules/extract-zip": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
-      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "debug": "^4.1.1",
-        "get-stream": "^5.1.0",
-        "yauzl": "^2.10.0"
-      },
-      "bin": {
-        "extract-zip": "cli.js"
-      },
-      "engines": {
-        "node": ">= 10.17.0"
-      },
-      "optionalDependencies": {
-        "@types/yauzl": "^2.9.1"
-      }
-    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -7232,16 +7217,6 @@
       "license": "ISC",
       "dependencies": {
         "reusify": "^1.0.4"
-      }
-    },
-    "node_modules/fd-slicer": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
-      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "pend": "~1.2.0"
       }
     },
     "node_modules/fdir": {
@@ -9855,13 +9830,6 @@
         "type": "github",
         "url": "https://github.com/sponsors/jet2jet"
       }
-    },
-    "node_modules/pend": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
-      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -12733,17 +12701,6 @@
       "license": "ISC",
       "engines": {
         "node": ">=12"
-      }
-    },
-    "node_modules/yauzl": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
-      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "buffer-crc32": "~0.2.3",
-        "fd-slicer": "~1.1.0"
       }
     },
     "node_modules/yocto-queue": {

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "bootstrap-icons": "^1.13.1",
     "concurrently": "^9.2.1",
     "css-loader": "^7.1.2",
-    "electron": "^38.2.0",
+    "electron": "^43.3.0",
     "electron-builder": "^26.0.12",
     "eslint": "^9.39.5",
     "eslint-config-airbnb-extended": "^3.2.0",


### PR DESCRIPTION
Closes all 18 open Dependabot alerts. Every one of them was `electron` itself — there were no alerts on any other npm package, and the Python tree (`py/requirements.txt`) is clean.

## Why 43 and not 39

Two things about how GitHub reports these are misleading:

**The `development` scope label is not what it looks like.** All 18 alerts are tagged `development` because `electron` sits in `devDependencies`. That placement is mandatory — `electron-builder` bundles anything in `dependencies` into `app.asar`. Electron 38.8.6 *is* the runtime shipped in every macOS/Windows/Pi artifact, so the "dev-only, low stakes" reading doesn't apply to any of them.

**`first_patched_version` points at an already-EOL branch.** Every advisory lists 39.8.x as first-patched only because 38 never got a backport — 38.8.6 is the terminal 38.x release. Electron supports the newest three majors, and `npm view electron dist-tags` gives `latest: 43.3.0`, so 39 and 40 are EOL too. Bumping to 39.8.10 would have zeroed the alert list and landed us on a branch that immediately starts collecting new ones.

## Reachability

None of the 18 was realistically exploitable, because of the app's shape: the board opens in the **system browser** via `shell.openExternal`, so almost nothing runs inside Electron. Only two `BrowserWindow`s exist — the update window (`loadFile`, CSP `default-src 'none'`, `contextIsolation: true`) and the About window (`loadURL` to the loopback Tornado, default `webPreferences`).

Verified unused across `main.js`, `electron/`, and `js/`: offscreen rendering, `<webview>`, custom protocol registration, extension loading, `setWindowOpenHandler`, permission handlers, `clipboard.readImage`, programmatic DevTools, and iframes.

- **8 alerts are unreachable outright** — the feature is never enabled. This includes two of the four highs: the offscreen child-window paint UAF (#55) and the custom-protocol CORS bypass (#119).
- **8 require hostile content** inside one of those two windows, which only ever load a local file or our own loopback server.
- **2 are DevTools-gated** (#123, #125); nothing opens DevTools programmatically.

The one worth acting on is **#116, the contextBridge `Function.prototype.bind` context isolation bypass**. It names the exact pattern in `electron/update-window-preload.js` (Promise-returning functions over `contextBridge`), it sits in front of the download-and-install-an-update IPC, and the advisory states there is no app-side workaround.

## Verification

| Check | Result |
|---|---|
| `python -m pytest py/tests -q` | 224 passed (unchanged baseline) |
| `npm run test:js` | 72 passed, 0 failed |
| `npx eslint js/` | exit 0 — 12 pre-existing `no-console` warnings, 0 errors |
| `npm install` | 0 vulnerabilities |

No bundle rebuild is required: webpack only covers the `js/` frontend entries (`app`, `venue`, `web`, `about`), while `main.js` and `electron/` ship unbundled.

The lockfile diff is small for a five-major bump — the only movement beyond the version itself is inside Electron's own tree (it now vendors `@electron-internal/extract-zip` in place of the `extract-zip`/`yauzl`/`fd-slicer` chain, and bumps its bundled `@types/node`). `electron-builder`, the `overrides` block, and the vendored `boolean` are untouched.

## Not verified — needs doing before release

**No local check validates an Electron bump.** `pytest` is Python-only, `eslint js/` skips `electron/`, and `npm run test:js` injects the electron import specifically so it runs without the binary (see the note at `.github/workflows/ci.yml:58`). The Electron binary postinstall also did not run in the environment this was prepared in, so the app was never launched.

Before cutting a release this needs a real packaged build per platform, exercised by hand:

- [ ] Tray menu, About window, Edit Configuration, log consolidation/open
- [ ] Update prompt end to end
- [ ] macOS signing + notarization
- [ ] `electron-updater` 6.8.9 against Electron 43

🤖 Generated with [Claude Code](https://claude.com/claude-code)
