### PR TITLE
chore(version): rebuild and stage the bundles on a version bump

### DIFF
--- a/scripts/sync-version.js
+++ b/scripts/sync-version.js
@@ -8,6 +8,7 @@ const PROJECT_ROOT = path.resolve(__dirname, '..');
 const PACKAGE_JSON_PATH = path.join(PROJECT_ROOT, 'package.json');
 const PY_VERSION_PATH = path.join(PROJECT_ROOT, 'py', 'version.py');
 const RELATIVE_PY_VERSION_PATH = path.relative(PROJECT_ROOT, PY_VERSION_PATH);
+const WEBPACK_CONFIG_PATH = path.join(PROJECT_ROOT, 'webpack.config.js');
 
 function getPackageVersion() {
   const packageJson = JSON.parse(fs.readFileSync(PACKAGE_JSON_PATH, 'utf8'));
@@ -26,21 +27,75 @@ function writePythonVersion(version) {
   fs.writeFileSync(PY_VERSION_PATH, header + body, 'utf8');
 }
 
-function stagePythonVersionFile() {
-  const result = spawnSync('git', ['add', RELATIVE_PY_VERSION_PATH], {
+function stage(relativePaths, description) {
+  const result = spawnSync('git', ['add', ...relativePaths], {
     stdio: 'inherit',
     cwd: PROJECT_ROOT,
   });
   if (result.status !== 0) {
-    throw new Error('Failed to stage py/version.py.');
+    throw new Error(`Failed to stage ${description}.`);
   }
 }
 
+// webpack bakes the version into the bundles through DefinePlugin, so they are
+// as much a generated artifact of package.json as py/version.py is. 1.10.0
+// shipped with bundles still reporting 1.9.1 because the bump regenerated one
+// and not the other; rebuilding here is what stops that recurring.
+function rebuildBundles(npmCli) {
+  const result = spawnSync(process.execPath, [npmCli, 'run', 'build'], {
+    stdio: 'inherit',
+    cwd: PROJECT_ROOT,
+  });
+  if (result.status !== 0) {
+    throw new Error('Failed to rebuild the frontend bundles (`npm run build`).');
+  }
+}
+
+// Read the entry points off the webpack config rather than listing them here.
+// A hardcoded list that quietly falls behind a new entry would reintroduce the
+// exact staleness this build exists to prevent.
+function bundleOutputPaths() {
+  const { entry, output } = require(WEBPACK_CONFIG_PATH);
+  return Object.keys(entry).flatMap((name) => {
+    const bundle = path.join(output.path, output.filename.replace('[name]', name));
+    // devtool is 'source-map', so every bundle has a sibling map. webpack also
+    // writes a LICENSE.txt next to any bundle carrying a preserved banner --
+    // only some entries have one, hence the existence filter. Its content does
+    // not move with the version, but the rebuild rewrites it with LF endings,
+    // and staging it is what stops `npm version` leaving a tree that reads as
+    // modified over nothing but core.autocrlf.
+    return [bundle, `${bundle}.map`, `${bundle}.LICENSE.txt`];
+  })
+    .filter(file => fs.existsSync(file))
+    .map(file => path.relative(PROJECT_ROOT, file));
+}
+
+// npm points npm_execpath at its own CLI while running a lifecycle script, so
+// running that under the current node reaches `npm run build` with no dependence
+// on a shim being resolvable on PATH -- which matters on Windows, where node
+// refuses to spawn npm.cmd without a shell, and `shell: true` concatenates
+// arguments rather than escaping them (Node DEP0190). Checked up front so an
+// invocation that cannot finish does not leave py/version.py rewritten first.
+function resolveNpmCli() {
+  const npmCli = process.env.npm_execpath;
+  if (!npmCli) {
+    throw new Error(
+      'sync-version.js expects to run as an npm lifecycle script (npm_execpath is unset).\n'
+      + 'Run `npm version <bump>`, or `npm run build` by hand if you only want the bundles.',
+    );
+  }
+  return npmCli;
+}
+
 try {
+  const npmCli = resolveNpmCli();
   const version = getPackageVersion();
   writePythonVersion(version);
-  stagePythonVersionFile();
-  console.log(`Synchronized py/version.py to ${version}`);
+  stage([RELATIVE_PY_VERSION_PATH], 'py/version.py');
+  rebuildBundles(npmCli);
+  const bundles = bundleOutputPaths();
+  stage(bundles, 'the rebuilt frontend bundles');
+  console.log(`Synchronized py/version.py and ${bundles.length} bundle files to ${version}`);
 } catch (error) {
   console.error(error.message);
   process.exit(1);


### PR DESCRIPTION
Follow-up to #60, which rebuilt the stale bundles but left the cause in place.

`npm version` regenerated `py/version.py` and not the frontend bundles, even though webpack bakes the version into them via `DefinePlugin` just the same. That asymmetry is why 1.10.0 shipped with bundles still reporting 1.9.1. Without this, the next bump does it again.

`scripts/sync-version.js` now runs `npm run build` after writing `py/version.py` and stages the outputs alongside it, so both generated artifacts land in the same version commit — the pattern `py/version.py` already followed.

## Decisions worth reviewing

**Entries are read off `webpack.config.js`, not listed in the script.** A hardcoded list that fell behind a newly added entry would reintroduce exactly the staleness this is meant to prevent.

**The build runs as `npm run build` through `process.env.npm_execpath` under the current node.** Two alternatives were tried and rejected: naming `npm.cmd` directly fails on Windows because node refuses to spawn `.cmd` without a shell, and `shell: true` trips Node's DEP0190 (arguments concatenated rather than escaped). Going through the npm script rather than invoking webpack directly keeps `package.json` the single place the build flags live.

**`npm_execpath` is checked before anything is written**, so an invocation that can't finish doesn't leave `py/version.py` rewritten behind it. Run outside npm, the script exits with a message naming `npm version` and touches nothing.

**webpack's `LICENSE.txt` outputs are staged too.** Their content doesn't move with the version, but the rebuild rewrites them with LF endings, and under `core.autocrlf=true` that alone leaves the tree reading as modified after a bump. Only some entries emit one, hence the existence filter.

## Verification

Simulated a bump to `9.9.9-test`:

- `py/version.py`, `static/about.js`, `static/app.js` and both `.map` files staged carrying the new version
- `venue.js` / `web.js` added but producing no diff — neither references `VERSION`, so nothing spurious is swept into the commit
- no `LICENSE.txt` left dirty afterwards
- run without npm: clean error, tree untouched

Suites: 224 pytest passing, 72 node tests passing, `eslint js/` clean.

## Note on scope

This closes the generation gap but adds no independent check — CI builds into its own workspace and never compares against the committed `static/`, so it still can't detect drift introduced some other way. A CI step that rebuilds and fails on a dirty tree would cover that, and is deliberately not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
