### PR TITLE
fix(scripts): make server:watch ignores and server:sys work on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "server": "node scripts/run-server.js",
     "server:venv": "node scripts/run-server.js",
-    "server:sys": "python3 py/wirelessboard.py",
+    "server:sys": "node scripts/run-server.js --system",
     "setup:venv": "node scripts/setup-venv.js",
     "postinstall": "npm run setup:venv",
     "build": "node node_modules/webpack/bin/webpack.js --mode production --progress --config=webpack.config.js",
@@ -14,7 +14,7 @@
     "test": "npm run test:py && npm run test:js",
     "test:py": "node scripts/run-pytest.js",
     "build:dev": "node node_modules/webpack/bin/webpack.js --mode development --watch --config=webpack.config.js",
-    "server:watch": "nodemon --watch static --watch demo.html --watch css --watch js --watch py --ignore 'config/config.json' --ignore 'config/**/*.json' --ext js,json,html,css,py --exec \"node scripts/run-server.js\"",
+    "server:watch": "nodemon --watch static --watch demo.html --watch css --watch js --watch py --ignore \"config/config.json\" --ignore \"config/**/*.json\" --ext js,json,html,css,py --exec \"node scripts/run-server.js\"",
     "dev": "concurrently \"npm run build:dev\" \"npm run server:watch\"",
     "bundle:server": "node scripts/run-pyinstaller.js",
     "bundle:server:win": "node scripts/build-universal.js",

--- a/scripts/run-server.js
+++ b/scripts/run-server.js
@@ -10,6 +10,11 @@
  *
  * Prefers the virtualenv, falls back to PATH so a system-installed set of
  * dependencies keeps working. Mirrors the resolution order in run-pytest.js.
+ *
+ * Pass --system to skip the virtualenv deliberately, which is what server:sys
+ * wants. It used to name `python3`, but on Windows that reaches the Store alias
+ * stub rather than an interpreter, so the script opened the Microsoft Store
+ * instead of starting anything.
  */
 const path = require('path');
 const fs = require('fs');
@@ -29,18 +34,35 @@ function venvPython() {
   return null;
 }
 
-function resolveInterpreter() {
+// `python3` is not a safe name for this on Windows: the Store alias stub
+// answers to it whether or not an interpreter is installed. `python` is what
+// resolves to a real one, which is why the platforms differ here.
+function systemPython() {
+  return process.platform === 'win32' ? 'python' : 'python3';
+}
+
+function resolveInterpreter({ system }) {
+  // An explicit interpreter stays the most specific instruction, so it wins
+  // over --system rather than the other way round.
   const override = process.env.WIRELESSBOARD_PYTHON && process.env.WIRELESSBOARD_PYTHON.trim();
   if (override) return override;
+
+  if (system) return systemPython();
 
   const venv = venvPython();
   if (venv) return venv;
 
-  return process.platform === 'win32' ? 'python' : 'python3';
+  return systemPython();
 }
 
-const python = resolveInterpreter();
-const args = [path.join('py', 'wirelessboard.py'), ...process.argv.slice(2)];
+// --system is ours; everything else belongs to wirelessboard.py.
+const passthrough = process.argv.slice(2);
+const systemIndex = passthrough.indexOf('--system');
+const system = systemIndex !== -1;
+if (system) passthrough.splice(systemIndex, 1);
+
+const python = resolveInterpreter({ system });
+const args = [path.join('py', 'wirelessboard.py'), ...passthrough];
 const result = spawnSync(python, args, { cwd: projectRoot, stdio: 'inherit' });
 
 if (result.error) {


### PR DESCRIPTION
The two Windows issues flagged but deliberately left out of #62.

## `server:watch` — the ignore patterns never matched

The `--ignore` arguments were quoted POSIX-style. `cmd.exe` doesn't treat single quotes as quoting, so nodemon received the literal `'config/config.json'` — quote characters included — and compiled it into a regex that could only match a path containing quotes.

So the ignore silently never fired, which is the opposite of its purpose, and `config/config.json` is precisely the file a running server rewrites. Given this repo's history with config durability, an ignore rule that quietly does nothing is worth more than a cosmetic fix.

Confirmed with `nodemon --dump` through `cmd.exe`. Before:

```
"'config/config.json'"
re: /...|'config\/config\.json'/
```

After:

```
'config/config.json'
```

Double quotes fix `cmd.exe` and change nothing under `sh`, which strips them the same way while still protecting the glob from shell expansion.

## `server:sys` — reached the Store alias stub, not an interpreter

`python3` on Windows hits the Microsoft Store alias, which opens the Store rather than starting anything. It now runs through `run-server.js` with a new `--system` flag that skips the virtualenv deliberately and picks the right name per platform (`python` on Windows, `python3` elsewhere).

Two details: `WIRELESSBOARD_PYTHON` still wins over `--system`, since an explicit interpreter path is the more specific instruction; and the flag is consumed rather than forwarded on to `wirelessboard.py`.

## Verification (on Windows)

- **`server:sys`** reaches a real interpreter and genuinely bypasses the venv — it now fails with `No module named 'keyring'`, a venv-only dependency, having gotten far enough to import the project's own modules first. Failing loudly when the system interpreter lacks the dependencies is the intent of that script.
- **`npm run server`** still serves **HTTP 200** on 8058 (regression check — `run-server.js` argument handling changed).
- **`npm run server:watch`** starts the service through nodemon and serves **HTTP 200**.

Suites: 224 pytest passing, 72 node tests passing, `eslint js/` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
