### PR TITLE
feat(updater): make the automatic update check configurable

### DIFF
--- a/docs/electron.md
+++ b/docs/electron.md
@@ -9,6 +9,21 @@ The Wirelessboard server is written in Python. [PyInstaller](https://pyinstaller
 
 The Electron wrapper is written in JavaScript. It provides a menubar app with access to Wirelessboard, its configuration directory, and the Wirelessboard logs. The menu labels continue to include “Micboard” when running in legacy compatibility mode.
 
+## Update checks
+
+The desktop app looks for a newer release 30 seconds after launch and every six hours after that. It never downloads or installs anything on its own — it reports what is available and leaves the decision to the operator, because this runs during live services.
+
+Two controls in the tray menu:
+
+- **Check for Updates Now** — asks immediately. Available whether or not automatic checks are on.
+- **Check for Updates Automatically** — turn the periodic check off for sites that manage their own update windows, run offline, or are on a locked-down network. On by default.
+
+Both settings live in `update-state.json`, beside `config.json` in the configuration directory, alongside the version whose prompt was last dismissed. Nothing in the Electron app writes `config.json`.
+
+Turning automatic checks off stops the periodic check and the prompt it raises. It does not hide an update already found, and it does not disable **Check for Updates Now** — off means "stop doing this on your own", not "refuse when I ask".
+
+Dismissing a prompt is separate and applies to one version: it stops that release interrupting you, while the tray keeps reporting it until it is installed or superseded.
+
 ## Building Cross-Platform Releases
 Wirelessboard now ships with repeatable release scripts and a GitHub Actions workflow that publish artefacts for macOS, Windows, and Raspberry Pi. The Python backend is bundled with PyInstaller while [`electron-builder`](https://www.electron.build) produces the desktop shells.
 

--- a/electron/update-settings.js
+++ b/electron/update-settings.js
@@ -1,0 +1,75 @@
+/**
+ * The shape of update-state.json, and the rules for changing it.
+ *
+ * The file started out holding one key -- the version whose prompt had been
+ * dismissed -- and was written by replacing the whole object with that key. A
+ * second key could not survive that: turning automatic checks off and then
+ * dismissing a prompt would have silently turned them back on. So every write
+ * merges onto what is already there, and anything this module does not know
+ * about is carried through untouched rather than dropped.
+ *
+ * Pure by design, like update-check.js and update-prompt.js beside it, so the
+ * rules can be tested without a filesystem or an electron import.
+ */
+
+// Checks stay on unless somebody says otherwise. A board that quietly stopped
+// looking for updates would be worse than one that asks.
+const DEFAULTS = Object.freeze({
+  automaticChecks: true,
+});
+
+function isPlainObject(value) {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value);
+}
+
+/**
+ * What the file means, given whatever was actually in it.
+ *
+ * A missing or malformed value falls back to the default rather than being
+ * treated as false: the cost of guessing "on" is one prompt too many, and the
+ * cost of guessing "off" is a board that never mentions a security update
+ * again.
+ */
+function normalizeSettings(parsed) {
+  const source = isPlainObject(parsed) ? parsed : {};
+  return {
+    automaticChecks: typeof source.automaticChecks === 'boolean'
+      ? source.automaticChecks
+      : DEFAULTS.automaticChecks,
+  };
+}
+
+/**
+ * The object to write, given what is on disk and what is being changed.
+ *
+ * Unknown keys are preserved deliberately: a newer build may have written
+ * something this one has never heard of, and an older build quietly discarding
+ * a user's settings is a bad way to find that out.
+ */
+function mergeSettings(existing, patch) {
+  const base = isPlainObject(existing) ? existing : {};
+  const change = isPlainObject(patch) ? patch : {};
+  return { ...base, ...change };
+}
+
+/**
+ * Whether a check should go ahead.
+ *
+ * A check the operator asked for by hand always goes ahead -- switching the
+ * automatic checks off means "stop doing this on your own", not "refuse when I
+ * ask". Without that, turning them off would leave no way to update
+ * deliberately short of editing a file.
+ */
+function shouldCheck({ settings, manual = false } = {}) {
+  if (manual) {
+    return true;
+  }
+  return normalizeSettings(settings).automaticChecks;
+}
+
+module.exports = {
+  DEFAULTS,
+  normalizeSettings,
+  mergeSettings,
+  shouldCheck,
+};

--- a/electron/update-settings.test.js
+++ b/electron/update-settings.test.js
@@ -1,0 +1,76 @@
+/**
+ * Tests for the update-state.json rules. Run with `npm run test:js`.
+ */
+const test = require('node:test');
+const assert = require('node:assert');
+
+const {
+  normalizeSettings, mergeSettings, shouldCheck, DEFAULTS,
+} = require('./update-settings');
+
+test('automatic checks are on by default', () => {
+  // A board that quietly stopped looking for updates is worse than one that asks.
+  assert.strictEqual(DEFAULTS.automaticChecks, true);
+  assert.strictEqual(normalizeSettings(undefined).automaticChecks, true);
+  assert.strictEqual(normalizeSettings({}).automaticChecks, true);
+});
+
+test('an explicit false is honoured', () => {
+  assert.strictEqual(normalizeSettings({ automaticChecks: false }).automaticChecks, false);
+});
+
+test('a malformed value falls back to on rather than off', () => {
+  // Guessing "on" costs one prompt; guessing "off" costs every future security
+  // update going unmentioned.
+  ['no', 0, null, [], {}].forEach((value) => {
+    assert.strictEqual(
+      normalizeSettings({ automaticChecks: value }).automaticChecks,
+      true,
+      `expected ${JSON.stringify(value)} to fall back to on`,
+    );
+  });
+});
+
+test('a non-object file does not throw', () => {
+  assert.strictEqual(normalizeSettings(null).automaticChecks, true);
+  assert.strictEqual(normalizeSettings('nonsense').automaticChecks, true);
+  assert.strictEqual(normalizeSettings([1, 2]).automaticChecks, true);
+});
+
+test('merging keeps the keys it is not changing', () => {
+  // The bug this exists to prevent: writing a dismissal used to replace the
+  // whole object, so it would have switched automatic checks back on.
+  const existing = { dismissedVersion: '1.9.1', automaticChecks: false };
+  const merged = mergeSettings(existing, { dismissedVersion: '1.10.0' });
+  assert.strictEqual(merged.automaticChecks, false);
+  assert.strictEqual(merged.dismissedVersion, '1.10.0');
+});
+
+test('merging preserves keys this build has never heard of', () => {
+  // An older build downgrading a newer build's settings file would be a bad
+  // way to discover the format had moved on.
+  const merged = mergeSettings({ somethingNewer: 42 }, { automaticChecks: false });
+  assert.strictEqual(merged.somethingNewer, 42);
+  assert.strictEqual(merged.automaticChecks, false);
+});
+
+test('merging tolerates rubbish on either side', () => {
+  assert.deepStrictEqual(mergeSettings(null, { automaticChecks: false }), { automaticChecks: false });
+  assert.deepStrictEqual(mergeSettings({ a: 1 }, null), { a: 1 });
+  assert.deepStrictEqual(mergeSettings(undefined, undefined), {});
+});
+
+test('a scheduled check is skipped when automatic checks are off', () => {
+  assert.strictEqual(shouldCheck({ settings: { automaticChecks: false } }), false);
+  assert.strictEqual(shouldCheck({ settings: { automaticChecks: true } }), true);
+  assert.strictEqual(shouldCheck({ settings: {} }), true);
+});
+
+test('a check the operator asked for always goes ahead', () => {
+  // Off means "stop doing this on your own", not "refuse when I ask".
+  assert.strictEqual(shouldCheck({ settings: { automaticChecks: false }, manual: true }), true);
+});
+
+test('shouldCheck with no arguments does not throw', () => {
+  assert.strictEqual(shouldCheck(), true);
+});

--- a/main.js
+++ b/main.js
@@ -17,6 +17,7 @@ const { autoUpdater } = require('electron-updater');
 const servicePaths = require('./electron/service-paths');
 const updateCheck = require('./electron/update-check');
 const updatePrompt = require('./electron/update-prompt');
+const updateSettings = require('./electron/update-settings');
 
 let win;
 let tray;
@@ -330,25 +331,47 @@ function updateStatePath() {
   return resolveAppDataPath(UPDATE_STATE_FILE);
 }
 
-function readDismissedVersion() {
+function readUpdateStateFile() {
   try {
     const raw = fs.readFileSync(updateStatePath(), 'utf8');
     const parsed = JSON.parse(raw);
-    return updatePrompt.normalizeVersion(parsed && parsed.dismissedVersion);
+    return parsed && typeof parsed === 'object' ? parsed : {};
   } catch (err) {
-    // Absent or unreadable both mean "nothing dismissed". Never fatal: failing
-    // to remember a dismissal costs one extra prompt, which is the safe way to
-    // be wrong.
-    return null;
+    // Absent or unreadable both mean "nothing remembered". Never fatal: the
+    // cost is one extra prompt, which is the safe way to be wrong.
+    return {};
   }
 }
 
-function writeDismissedVersion(version) {
+// ⛔ Read, merge, write. This used to replace the whole file with the one key
+// it was changing, which was harmless while there was only one -- but a
+// dismissal would now switch automatic checks back on behind the operator.
+function patchUpdateState(patch) {
   try {
-    fs.writeFileSync(updateStatePath(), JSON.stringify({ dismissedVersion: version }, null, 2));
+    const merged = updateSettings.mergeSettings(readUpdateStateFile(), patch);
+    fs.writeFileSync(updateStatePath(), JSON.stringify(merged, null, 2));
+    return true;
   } catch (err) {
-    console.warn(`Could not remember the dismissed update version: ${err.message}`);
+    console.warn(`Could not save update settings: ${err.message}`);
+    return false;
   }
+}
+
+function readDismissedVersion() {
+  return updatePrompt.normalizeVersion(readUpdateStateFile().dismissedVersion);
+}
+
+function writeDismissedVersion(version) {
+  patchUpdateState({ dismissedVersion: version });
+}
+
+function automaticChecksEnabled() {
+  return updateSettings.normalizeSettings(readUpdateStateFile()).automaticChecks;
+}
+
+function setAutomaticChecks(enabled) {
+  patchUpdateState({ automaticChecks: Boolean(enabled) });
+  rebuildTrayMenu();
 }
 
 function pushUpdateState() {
@@ -490,7 +513,17 @@ function wireUpdater() {
   return autoUpdater;
 }
 
-async function runUpdateCheck() {
+async function runUpdateCheck({ manual = false } = {}) {
+  // Read at the point of use rather than caching: the operator can turn this
+  // off between the six-hourly firings, and the next one should already know.
+  if (!updateSettings.shouldCheck({ settings: readUpdateStateFile(), manual })) {
+    return;
+  }
+
+  if (manual) {
+    setUpdatePhase('checking', { message: 'Checking for updates…' });
+  }
+
   const result = await updateCheck.checkForUpdate({
     currentVersion: app.getVersion(),
     getJson,
@@ -629,6 +662,20 @@ app.on('ready', () => {
         enabled: ['available', 'downloading', 'ready'].includes(updatePhase),
         click() { showUpdateWindow(); },
       },
+      // Stays available whatever the checkbox says: switching the automatic
+      // checks off means "stop doing this on your own", and leaving no way to
+      // ask deliberately would make the setting a trap.
+      {
+        label: 'Check for Updates Now',
+        enabled: !['downloading', 'ready'].includes(updatePhase),
+        click() { runUpdateCheck({ manual: true }); },
+      },
+      {
+        label: 'Check for Updates Automatically',
+        type: 'checkbox',
+        checked: automaticChecksEnabled(),
+        click(menuItem) { setAutomaticChecks(menuItem.checked); },
+      },
       { type: 'separator' },
       { label: 'About', click() { createWindow(`${SERVICE_URL}/about`); } },
       { type: 'separator' },
@@ -651,8 +698,11 @@ app.on('ready', () => {
   // waiting on the server, and an update check has no business competing with
   // it. Six-hourly thereafter keeps this far inside GitHub's unauthenticated
   // rate limit.
-  setTimeout(runUpdateCheck, UPDATE_CHECK_DELAY_MS);
-  setInterval(runUpdateCheck, UPDATE_CHECK_INTERVAL_MS);
+  // The timers always run; runUpdateCheck decides whether to act on them by
+  // reading the setting each time. Cancelling and re-arming an interval as the
+  // checkbox is toggled would be more state to get wrong for no benefit.
+  setTimeout(() => runUpdateCheck(), UPDATE_CHECK_DELAY_MS);
+  setInterval(() => runUpdateCheck(), UPDATE_CHECK_INTERVAL_MS);
 });
 
 


### PR DESCRIPTION
Closes #68.

The check was unconditional — 30 seconds after launch, then every six hours, both hardcoded. The only lever was per-version dismissal, which answers "stop asking me about *this* release" and not "don't check on this machine". Sites that manage their own update windows, run offline, or sit on a locked-down network had to decline each release as it appeared.

## Two tray items

| | |
|---|---|
| **Check for Updates Now** | Asks immediately |
| **Check for Updates Automatically** | Checkbox, on by default |

**Now** stays available whatever the checkbox says. Off means "stop doing this on your own", not "refuse when I ask" — leaving no way to ask deliberately would make the setting a trap, since disabling it would otherwise strand the board on whatever it was running.

## Where the setting lives — the open question on the issue

In `update-state.json`, which the Electron process already owns. **Not** in `config.json`.

Reading `config.json` from here would have been tolerable. Writing it would make a second process an author of the file whose corruption once left a server that could not start — and the settings UI has no way to reach the update timer anyway. Nothing in the Electron app writes `config.json`.

## A hazard the second key exposed

`writeDismissedVersion` replaced the **whole object** with the one key it was changing. Harmless while there was only one key — but with a second, dismissing a prompt would have silently switched automatic checks back on behind the operator.

Writes are now read-merge-write, and keys this build doesn't recognise are carried through rather than dropped, so an older build can't quietly downgrade a newer one's settings file. That's the case the merge tests are really about.

## Shape

`electron/update-settings.js` holds the rules — pure, no electron import, like `update-check.js` and `update-prompt.js` beside it. A malformed or missing value falls back to **on**: the cost of guessing on is one prompt too many; the cost of guessing off is a board that never mentions a security update again.

The timers still fire on schedule and `runUpdateCheck` reads the setting each time. Cancelling and re-arming an interval as the checkbox toggles would be more state to get wrong for no benefit, and this way a change takes effect at the next firing rather than needing a restart.

Documented in `docs/electron.md`, which had nothing about update behaviour at all.

## Verification

10 new unit tests covering the rules: the default, an explicit false, malformed values falling back to on, a non-object file not throwing, merge preserving both the key it isn't changing and keys it has never heard of, the scheduled-vs-manual distinction.

Suites: 224 pytest, 120 node tests (10 new), `eslint js/` clean. No frontend change, so no bundle rebuild.

**⏳ Not verified on hardware.** `electron-updater` refuses to run unpackaged and the tray can't be driven from a source checkout, so the menu items, the checkbox state and the file round-trip have not been exercised — only the rules, by unit test. This is the same limit the updater has always had, and it now joins the list of things wanting a real packaged build: Electron 43 itself, the transpiled `@shopify/draggable`, the reworked slot card, and the new layout geometry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
